### PR TITLE
Re-raise `StandardError` as `Vagrant::Errors::CLIInvalidUsage`

### DIFF
--- a/lib/vagrant_plugins/trellis_sequel/commands/root.rb
+++ b/lib/vagrant_plugins/trellis_sequel/commands/root.rb
@@ -30,6 +30,10 @@ module VagrantPlugins
           @subcommands.get(@sub_command&.to_sym)
                       .new(@sub_args, @env)
                       .execute
+        rescue Vagrant::Errors::VagrantError => e
+          raise e
+        rescue StandardError => e
+          raise Vagrant::Errors::CLIInvalidUsage, help: e.message
         end
 
         private

--- a/lib/vagrant_plugins/trellis_sequel/vault.rb
+++ b/lib/vagrant_plugins/trellis_sequel/vault.rb
@@ -26,9 +26,7 @@ module VagrantPlugins
       def database_for(site: nil, **_)
         site ||= first_wordpress_site
 
-        unless password_exist_for?(site)
-          raise Vagrant::Errors::CLIInvalidOptions.new help: "DB password not found for #{site}"
-        end
+        raise "DB password not found for #{site}" unless password_exist_for?(site)
 
         {
           name: db_name_for(site),


### PR DESCRIPTION
Ensure vagrant display nice error messages when bad things happen.